### PR TITLE
Make robot vote on all pull requests

### DIFF
--- a/Scripts/robot.py
+++ b/Scripts/robot.py
@@ -36,6 +36,8 @@ class Robot:
                 if 'communityManaged' in robotText:
                     projectIsCommunityManaged = True
             
+            projectIsCommunityManaged = True
+            
             #if the project is community managed we need to see if there are pull requests to merge
             if projectIsCommunityManaged:
                 '''


### PR DESCRIPTION
Currently it is possible to create projects which cannot be deleted by the community which is a problem since the community garden has no moderators. Rather than designate moderators, I am going to make the robot call a vote on all projects. If the project is actively managed by someone they have 48 hours to veto the vote, but if the project is abandoned the community will be able to update or remove it.